### PR TITLE
update api to click >= 8.1.0

### DIFF
--- a/tc420/__main__.py
+++ b/tc420/__main__.py
@@ -283,7 +283,7 @@ def demo(ctx: Context, channel_mask: Tuple[int, int, int, int, int]):
         return None  # Stop iteration
 
 
-@cmd_group.resultcallback()
+@cmd_group.result_callback()
 @click.pass_context
 def finalize(ctx: Context, _):
     """


### PR DESCRIPTION
resultcallback was renamed in click version 8.1.0
https://click.palletsprojects.com/en/8.1.x/changes/#version-8-1-0