### PR TITLE
Allow non-sudo usage of tc420

### DIFF
--- a/etc/udev/rules.d/99-tc420.rules
+++ b/etc/udev/rules.d/99-tc420.rules
@@ -4,4 +4,4 @@
 ### Add your user into plugdev group
 # sudo adduser your_user_name plugdev
 ### Logout and login to apply new group setting
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0888", ATTRS{idProduct}=="4000", GROUP="plugdev", MODE="0664"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0888", ATTRS{idProduct}=="4000", GROUP="plugdev", MODE="0666"


### PR DESCRIPTION
Using the tc420 command line tool on various Linux systems, I always needed to run it via sudo. Now I'm embedding the class TC420 in a larger project, where this is no option.

On stackoverflow I found the hint to have the udev rule set MODE="0666" instead of "0664". I'm far from understanding udev, but this change seems to help.