### PR TITLE
Fix name of @cmd_group.result_callback()

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,13 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+tc420 = {file = ".", editable = true}
+
+[dev-packages]
+tc420 = {file = "."}
+
+[requires]
+python_version = "3.12"

--- a/tc420/__main__.py
+++ b/tc420/__main__.py
@@ -283,7 +283,7 @@ def demo(ctx: Context, channel_mask: Tuple[int, int, int, int, int]):
         return None  # Stop iteration
 
 
-@cmd_group.resultcallback()
+@cmd_group.result_callback()
 @click.pass_context
 def finalize(ctx: Context, _):
     """


### PR DESCRIPTION
When I tried to run a simple command of tc420, I get an error about a name resolution:

Traceback (most recent call last):
  File "/home/user/.local/share/virtualenvs/tc420-7Nt0gyJ3/bin/tc420", line 5, in <module>
    from tc420.__main__ import main
  File "/home/user/src/tc420/tc420/__main__.py", line 286, in <module>
    @cmd_group.resultcallback()
     ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Group' object has no attribute 'resultcallback'. Did you mean: 'result_callback'?

This patch fixes this error by adjusting the name.